### PR TITLE
fix: correct stdin handling in JSON validation and improve Linux compatibility in INSTALL.md

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -6,13 +6,21 @@
 2. 将 `skills/arming-thought/SKILL.md` 作为新会话的起始方法论入口。
 3. 具体任务开始后，再按需读取对应 `skills/*/SKILL.md`。
 4. 如果 OpenCode 支持命令目录，则一并加载 `commands/`；否则直接读取对应命令文件内容。
-5. 优先运行：
+5. 如果当前环境已安装Node.js，优先运行：
 
 ```bash
 npx qiushi-skill validate
 ```
 
-6. 如果当前环境没有 Node.js，再在 Windows 上执行：
+6. 如果当前环境没有 Node.js，检查当前的运行系统。
+
+如果是Linux 或MacOS系统，执行：
+
+```sh
+bash tests/validate.sh
+```
+
+如果是Windows系统，执行：
 
 ```powershell
 powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File tests/validate.ps1

--- a/tests/validate.sh
+++ b/tests/validate.sh
@@ -36,13 +36,11 @@ json_validate_file() {
 
   case "$JSON_RUNNER" in
     python3|python)
-      PYTHONUTF8=1 PYTHONIOENCODING=UTF-8 "$JSON_RUNNER" - "$file_path" <<'PY' >/dev/null 2>&1
-import json
-import sys
-
+      PYTHONUTF8=1 PYTHONIOENCODING=UTF-8 "$JSON_RUNNER" -c '
+import json, sys
 with open(sys.argv[1], "r", encoding="utf-8") as handle:
     json.load(handle)
-PY
+' "$file_path" >/dev/null 2>&1
       ;;
     node)
       node -e "JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'))" "$file_path" >/dev/null 2>&1
@@ -56,12 +54,10 @@ PY
 json_validate_stdin() {
   case "$JSON_RUNNER" in
     python3|python)
-      PYTHONUTF8=1 PYTHONIOENCODING=UTF-8 "$JSON_RUNNER" - <<'PY' >/dev/null 2>&1
-import json
-import sys
-
+      PYTHONUTF8=1 PYTHONIOENCODING=UTF-8 "$JSON_RUNNER" -c '
+import json, sys
 json.load(sys.stdin)
-PY
+' >/dev/null 2>&1
       ;;
     node)
       node -e "JSON.parse(require('fs').readFileSync(0, 'utf8'))" >/dev/null 2>&1


### PR DESCRIPTION
### Summary

- Fix JSON validation bug caused by heredoc overriding stdin and switch it to `python -c` type to preserve piped input
- Update INSTALL.md to improve Linux compatibility

### Details

Using heredoc (`python - <<'PY'`) caused stdin to be consumed by the inline script instead of the pipeline, resulting in empty input during JSON validation. This led to errors like:

    Expecting value: line 1 column 1 (char 0)

This PR replaces it with `python -c`, ensuring correct stdin handling.

Also updates INSTALL.md to ensure opencode validation steps work properly on Linux.