### PR TITLE
feat: 添加 nanobot 平台支持

### DIFF
--- a/.nanobot/INSTALL.md
+++ b/.nanobot/INSTALL.md
@@ -1,0 +1,25 @@
+# qiushi-skill for nanobot
+
+按下面步骤接入：
+
+1. 确认仓库已克隆到本地。
+2. 将 `skills/` 目录下的所有 skill 文件夹复制到 nanobot 工作区的 skills 目录：
+
+   ```bash
+   # 默认工作区路径为 ~/.nanobot/workspace
+   mkdir -p ~/.nanobot/workspace/skills
+   cp -r skills/* ~/.nanobot/workspace/skills/
+   ```
+
+3. nanobot 会自动发现新 skill。新会话开始时，`arming-thought` 的 name + description 会出现在 skill 列表中；当任务匹配某个方法论时，agent 会按需读取对应 `SKILL.md`。
+4. 如果需要 `arming-thought` 在每次会话中自动全量加载（而非仅展示摘要），可以在 SKILL.md 的 frontmatter 中添加 `always: true`。
+5. 在 Windows 上执行：
+
+```powershell
+powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File tests/validate.ps1
+```
+
+完成后，验证：
+
+- 在 nanobot 会话中检查 `arming-thought` 是否出现在可用 skill 列表中
+- 针对一个具体问题时，agent 能按需调用对应 skill，而不是机械全调用

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ npx claudepluginhub hughyau/qiushi-skill
    .opencode/INSTALL.md
    .openclaw/INSTALL.md
    .hermes/INSTALL.md
+   .nanobot/INSTALL.md
 
 6. 安装完成后执行：
    npx qiushi-skill validate
@@ -245,7 +246,7 @@ powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File tests/validate.ps1
 ```
 
 
-更多平台细节见根目录下的 `.codex/INSTALL.md`、`.opencode/INSTALL.md`、`.openclaw/INSTALL.md`、`.hermes/INSTALL.md`；源码仓库还包含 `docs/platforms.md`。
+更多平台细节见根目录下的 `.codex/INSTALL.md`、`.opencode/INSTALL.md`、`.openclaw/INSTALL.md`、`.hermes/INSTALL.md`、`.nanobot/INSTALL.md`；源码仓库还包含 `docs/platforms.md`。
 
 ## 📚 支撑文件
 
@@ -278,6 +279,7 @@ qiushi-skill/
 ├── .hermes/INSTALL.md                # Hermes Agent 安装入口
 ├── .opencode/INSTALL.md              # OpenCode 安装入口
 ├── .openclaw/INSTALL.md              # OpenClaw 安装入口
+├── .nanobot/INSTALL.md               # nanobot 安装入口
 ├── bin/
 │   ├── qiushi-skill.mjs              # npm CLI 主入口
 │   └── lib/                          # detect / install / validate 模块

--- a/docs/README.nanobot.md
+++ b/docs/README.nanobot.md
@@ -1,0 +1,33 @@
+# nanobot 使用说明
+
+`qiushi-skill` 在 nanobot 中以 skill 方式集成。核心做法是：将 `skills/` 目录复制到 nanobot 的工作区 skills 目录，nanobot 会自动发现并加载。
+
+## 快速开始
+
+1. 克隆仓库到本地。
+2. 让 nanobot 读取 [`.nanobot/INSTALL.md`](../.nanobot/INSTALL.md)。
+3. 将 skill 复制到 nanobot 工作区：
+
+   ```bash
+   mkdir -p ~/.nanobot/workspace/skills
+   cp -r skills/* ~/.nanobot/workspace/skills/
+   ```
+
+4. nanobot 会在新会话中自动发现所有 skill。
+5. 当任务匹配某个方法论时，agent 会按需加载对应 `SKILL.md`。
+
+## 推荐映射
+
+- 路由入口：`arming-thought`（每次会话自动出现在 skill 列表中）
+- 按需方法：`skills/*/SKILL.md`（agent 判断适用时自动加载）
+- 手动命令模板：`commands/*.md`（直接读取对应文件）
+
+## 验证
+
+Windows：
+
+```powershell
+powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File tests/validate.ps1
+```
+
+如果宿主不支持命令目录，就直接打开对应 `commands/*.md` 或 `skills/*/SKILL.md` 使用。

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -13,6 +13,7 @@
 | Hermes Agent | 通过原生 skills 目录支持 | 由 Hermes skills 暴露 | `.hermes/INSTALL.md` | `hermes skills list` + `npx qiushi-skill validate` |
 | Codex | 不依赖插件壳 | 视宿主能力而定 | `.codex/INSTALL.md` | 按文档自检 |
 | OpenCode | 不依赖插件壳 | 视宿主能力而定 | `.opencode/INSTALL.md` | 按文档自检 |
+| nanobot | 通过工作区 skills 目录自动发现 | 视宿主能力而定 | `.nanobot/INSTALL.md` | 按文档自检 |
 | 其他宿主 | 手动集成 | 视宿主能力而定 | 直接复用 `skills/` 和 `commands/` | 手动检查 |
 
 ## Claude Code
@@ -55,6 +56,22 @@ openclaw gateway restart
 3. 启动：`hermes chat --toolsets "skills,terminal"`
 
 更多说明见 [README.hermes.md](README.hermes.md)。
+
+## nanobot
+
+nanobot 通过工作区 skills 目录自动发现并加载 skill。将 `skills/` 目录复制到 nanobot 工作区即可完成接入。
+
+推荐步骤：
+
+1. 复制 `skills/` 到 `~/.nanobot/workspace/skills/`
+   ```bash
+   mkdir -p ~/.nanobot/workspace/skills
+   cp -r skills/* ~/.nanobot/workspace/skills/
+   ```
+2. 新会话中 nanobot 会自动发现所有 skill
+3. 当任务匹配某个方法论时，agent 会按需加载对应 `SKILL.md`
+
+更多说明见 [README.nanobot.md](README.nanobot.md)。
 
 ## Windows
 


### PR DESCRIPTION
## Summary

参考项目中已有的 Codex / OpenCode / Hermes 接入模式，新增 nanobot 平台支持。

nanobot 是一个开源 AI Agent 框架，通过工作区 `skills/` 目录自动发现和加载 skill（`~/.nanobot/workspace/skills/<name>/SKILL.md`），采用渐进式加载机制：summary → SKILL.md → 资源文件。

## 变更内容

| 文件 | 说明 |
|------|------|
| `.nanobot/INSTALL.md` | nanobot 安装入口，复制 skills 到工作区即可 |
| `docs/README.nanobot.md` | nanobot 使用说明文档 |
| `docs/platforms.md` | 平台支持表新增 nanobot 行 + 详细接入说明 |
| `README.md` | 安装指引、项目结构树、平台文档引用中添加 nanobot |

## 接入方式

```bash
mkdir -p ~/.nanobot/workspace/skills
cp -r skills/* ~/.nanobot/workspace/skills/
```

nanobot 会在新会话自动发现所有 skill，agent 按需加载对应 `SKILL.md`。

## Test plan

- [x] `.nanobot/INSTALL.md` 内容完整，步骤可执行
- [x] `docs/README.nanobot.md` 与 Codex/OpenCode 文档风格一致
- [x] `docs/platforms.md` 表格新增行格式对齐
- [x] `README.md` 中四处引用已同步更新