### PR TITLE
fix(hooks): make run-hook.cmd a POSIX/cmd polyglot for macOS & Linux

### DIFF
--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -1,3 +1,29 @@
+:; #
+:; # Polyglot hook runner: this single file works as both a POSIX shell script
+:; # (lines starting with `:;`) and a Windows .cmd batch file (the lines below
+:; # the blank separator).
+:; #
+:; # On macOS / Linux, /bin/sh executes this file directly (the `.cmd` suffix
+:; # is irrelevant on POSIX). The `:;` lines run normal shell commands; `:` is
+:; # a no-op builtin and `;` separates statements, so anything after `:;` is
+:; # plain sh code. We `exec` into the real hook script and never reach the
+:; # Windows section.
+:; #
+:; # On Windows, cmd.exe parses lines beginning with `:` as labels and skips
+:; # them during sequential execution, so the Windows logic below runs as if
+:; # this header were not present.
+:; #
+:; SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+:; HOOK_NAME="${1:-}"
+:; if [ -z "$HOOK_NAME" ]; then echo "Error: No hook name provided" >&2; exit 1; fi
+:; shift
+:; HOOK_PATH="$SCRIPT_DIR/$HOOK_NAME"
+:; if [ ! -e "$HOOK_PATH" ]; then echo "Error: hook not found: $HOOK_PATH" >&2; exit 1; fi
+:; if [ -x "$HOOK_PATH" ]; then exec "$HOOK_PATH" "$@"; fi
+:; if command -v bash >/dev/null 2>&1; then exec bash "$HOOK_PATH" "$@"; fi
+:; exec sh "$HOOK_PATH" "$@"
+:; exit 1
+
 @echo off
 setlocal
 


### PR DESCRIPTION
## Summary

Fixes the `SessionStart` hook on macOS / Linux. Closes #57.

`hooks/hooks.json` invokes `"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd" session-start` on every platform. On POSIX hosts `/bin/sh` cannot parse a Windows batch file, and the file additionally ships without `+x`, so the hook aborts with `Permission denied` and the `arming-thought` skill is never injected.

This PR makes `hooks/run-hook.cmd` a **polyglot** that is simultaneously valid POSIX shell and valid `cmd.exe` batch:

- Lines beginning with `:;` are no-ops in `sh` (`:` is a builtin, `;` separates statements) and label-like lines in `cmd.exe` (silently skipped during sequential execution).
- The POSIX prelude resolves the hook target, prefers a `+x` executable, falls back to `bash`, then `sh`, and `exec`s into it — `cmd.exe`'s section is never reached on POSIX.
- The original Windows logic is preserved verbatim below the prelude.
- The file is marked executable so `/bin/sh` can `fork`+`execve` it.

`hooks.json` is intentionally **not** modified — the same single-string command now works on all three platforms.

## Why a polyglot rather than two files

Claude Code's `hooks.json` exposes a single `command` string, dispatched by the OS-default shell. There is no `platform` field, so a clean per-OS dispatch from `hooks.json` would need either non-portable shell idioms (`if exist` vs `[ -e ]`) or a host-specific entry point. Keeping a single canonical file is the smallest, least invasive fix and preserves the existing `hooks.json` contract.

The polyglot pattern is the same one used by `sbt-extras` and other widely deployed cross-platform launchers.

## Verification (macOS, Darwin 25.4.0)

```
$ ./hooks/run-hook.cmd session-start </dev/null >/dev/null; echo $?
0

$ ./hooks/run-hook.cmd </dev/null
Error: No hook name provided
$ echo $?
1

$ ./hooks/run-hook.cmd does-not-exist </dev/null 2>&1
Error: hook not found: .../hooks/does-not-exist
$ echo $?
1

$ CLAUDE_PLUGIN_ROOT="$(pwd)" \
    sh -c '"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd" session-start' \
    </dev/null >/dev/null; echo $?    # exact form Claude Code dispatches
0
```

A hook script lacking `+x` also exercised cleanly via the `bash` fallback.

## Test plan for reviewers

- [ ] macOS / Linux: `./hooks/run-hook.cmd session-start` exits 0 and prints the `additional_context` JSON.
- [ ] macOS / Linux: starting a new Claude Code session no longer logs `Permission denied` and the `<QIUSHI_SKILL>` block appears in context.
- [ ] Windows (`cmd.exe`): existing behavior unchanged — the `:;` prelude is skipped, PowerShell / bash / sh fallbacks still fire as before.
- [ ] Windows PowerShell: still resolved via `session-start.ps1` through the `.cmd` adapter as before.

## Risk

Low. Behavior on Windows is preserved bit-for-bit (the prelude lines are inert labels). On POSIX the hook now works where it previously aborted.
